### PR TITLE
Fix Touch event in window7 with chrome --enable-touch-events

### DIFF
--- a/turn.js
+++ b/turn.js
@@ -29,7 +29,7 @@ var has3d,
 
 	A90 = PI/2,
 
-	isTouch = 'Touch' in window,
+	isTouch = 'ontouchstart' in window,
 
 	events = (isTouch) ? {start: 'touchstart', move: 'touchmove', end: 'touchend'}
 			: {start: 'mousedown', move: 'mousemove', end: 'mouseup'},


### PR DESCRIPTION
I tried it in chrome 19.0.1055.1 dev-m with `--enable-touch-events` in window7, but isTouch was always false because no `Touch` in window. So I think it cloud be better to use `ontouchstart` to check this is a touchpad or not.
